### PR TITLE
Add field dataRetentionTimeInDays to output; remove extraneous values

### DIFF
--- a/Snowflake-Database-Database/inputs/inputs_1_create.json
+++ b/Snowflake-Database-Database/inputs/inputs_1_create.json
@@ -1,0 +1,6 @@
+{
+    "Name": "ExampleName",
+    "DataRetentionTimeInDays": 90,
+    "MaxDataExtensionTimeInDays": 10,
+    "DefaultDdlCollation": "en-ci"
+}

--- a/Snowflake-Database-Database/inputs/inputs_1_invalid.json
+++ b/Snowflake-Database-Database/inputs/inputs_1_invalid.json
@@ -1,0 +1,12 @@
+{
+    "TPSCode": "...",
+    "Title": "...",
+    "CoverSheetIncluded": "...",
+    "DueDate": "...",
+    "ApprovalDate": "...",
+    "Memo": "...",
+    "SecondCopyOfMemo": "...",
+    "TestCode": "...",
+    "Authors": "...",
+    "Tags": "..."
+}

--- a/Snowflake-Database-Database/inputs/inputs_1_update.json
+++ b/Snowflake-Database-Database/inputs/inputs_1_update.json
@@ -1,0 +1,6 @@
+{
+    "Name": "ExampleName",
+    "DataRetentionTimeInDays": 90,
+    "MaxDataExtensionTimeInDays": 10,
+    "DefaultDdlCollation": "en-ci"
+}

--- a/Snowflake-Database-Database/src/handlers.ts
+++ b/Snowflake-Database-Database/src/handlers.ts
@@ -4,6 +4,7 @@ import {SnowflakeClient} from "../../Snowflake-Common/src/snowflake-client"
 import {NotFound}  from "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/dist/exceptions"
 import { ResourceModel, TypeConfigurationModel } from './models';
 import {version} from '../package.json';
+import { plainToClass, classToPlain } from 'class-transformer'
 
 type SnowflakeDatabase = {
     name: string,
@@ -108,14 +109,17 @@ class Resource extends AbstractSnowflakeResource<ResourceModel, SnowflakeDatabas
                 .transformKeys(CaseTransformer.SNAKE_TO_CAMEL)
                 .forModelIngestion()
                 .transform(),
-            comment: from.comment
+            comment: from.comment,
+            dataRetentionTimeInDays: from.retention_time
         });
 
         // The following are write-only and should not be returned
         delete result.maxDataExtensionTimeInDays
         delete result.defaultDdlCollation
 
-        return result
+        let plainObj = classToPlain(result);
+
+        return plainToClass(ResourceModel, plainObj, { excludeExtraneousValues: true });
     }
 }
 


### PR DESCRIPTION
This PR fixes failures in CTv2 due to (1) the non-writeOnlyProperties field `DataRetentionTimeInDays` not being returned as part of the CRUDL operation model output and (2) extraneous fields from the API call being included in the model output.

This PR also adds valid inputs within the inputs directory for contract testing.